### PR TITLE
Add primaryAxisStoneSize feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ WallLayout(
 | layersCount        | Define the number of layers the wall have. Must be higher or equal to 2. When direction is Axis.vertical, it defines the number of columns the wall has. When direction is Axis.horizontal, it defines the number of rows. | -                       |
 | wallBuilder        | Define how the wall is built: where each stone is positioned within the wall.The wall builder is allowed to use less stones than provided, and can create new stones (see ./example for more details). | WallBuilder.standard()  |
 | stonePadding       | Padding between stones. | 16.0                    |
+| primaryAxisStoneSize | Optional. If specified, indicates the exact size of each stone in the direction of the primary scroll axis. If not specified, each stone will be exactly square. | -                    |
 | scrollController   | Same as [ListView.scrollController]: "control the position to which this scroll view is scrolled". | -                       |
 | physics            | Same as [ListView.physics]: "How the scroll view should respond to user input". | -                       |
 | restorationId      | Same as [ListView.restorationId]: used "to save and restore the scroll offset of the scrollable". | -                       |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,7 +96,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
       duration: Duration(milliseconds: 200),
       reverseDuration: Duration(milliseconds: 200),
       alignment: Alignment.bottomRight,
-      vsync: this,
       child: Container(
         margin: EdgeInsets.only(left: 32),
         decoration: BoxDecoration(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
-        backgroundColor: Color(0xFFF5F5F5),
+        colorScheme: ColorScheme.light(background: Color(0xFFF5F5F5)),
       ),
       home: MyHomePage(title: 'Wall Layout Demo'),
     );
@@ -60,7 +60,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    final backgroundColor = Theme.of(context).backgroundColor;
+    final backgroundColor = Theme.of(context).colorScheme.background;
     return Scaffold(
       backgroundColor: backgroundColor,
       appBar: AppBar(
@@ -99,7 +99,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
       child: Container(
         margin: EdgeInsets.only(left: 32),
         decoration: BoxDecoration(
-          color: Theme.of(context).backgroundColor,
+          color: Theme.of(context).colorScheme.background,
           boxShadow: [
             BoxShadow(color: Colors.black26, blurRadius: 6.0),
           ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp();
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -35,6 +36,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   late final AnimationController _controller;
+  late bool _fixedPrimaryAxisStoneSize;
   late bool _reversed;
   late Axis _direction;
   late int _nbLayers;
@@ -47,6 +49,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
     super.initState();
     _controller =
         AnimationController(duration: Duration(milliseconds: 500), vsync: this);
+    _fixedPrimaryAxisStoneSize = false;
     _reversed = false;
     _direction = Axis.vertical;
     _nbLayers = 3;
@@ -117,6 +120,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                     __buildDivisionsOption(),
                     __buildDirectionOption(),
                     __buildReverseOption(),
+                    __buildFixedPrimaryAxisStoneSizeOption(),
                   ],
                 ),
               ),
@@ -144,6 +148,20 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
           if (_random) {
             _stones = _buildRandomStonesList(_nbLayers);
           }
+        }),
+      ),
+    );
+  }
+
+  Widget __buildFixedPrimaryAxisStoneSizeOption() {
+    return _buildOption(
+      "Fixed Primary Axis Size",
+      CupertinoSegmentedControl<bool>(
+        groupValue: _fixedPrimaryAxisStoneSize,
+        children: {false: Text("no"), true: Text("yes (300px)")},
+        onValueChanged: (value) => setState(() {
+          _controller.forward(from: 0.0);
+          _fixedPrimaryAxisStoneSize = value;
         }),
       ),
     );
@@ -216,6 +234,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
       stones: _stones,
       reverse: _reversed,
       layersCount: _nbLayers,
+      primaryAxisStoneSize: _fixedPrimaryAxisStoneSize ? 300 : null,
     );
   }
 

--- a/lib/src/wall_layout.dart
+++ b/lib/src/wall_layout.dart
@@ -68,7 +68,7 @@ class WallLayout extends StatefulWidget {
         assert(layersCount >= 2,
             "You must define layers count from as an integer higher or equal to 2"),
         assert(stonePadding >= 0.0),
-        assert(primaryAxisStoneSize == null || primaryAxisStoneSize >= 0.0),
+        assert(primaryAxisStoneSize == null || primaryAxisStoneSize > 0.0),
         assert(
             !(scrollController != null && primary == true),
             'Primary ScrollViews obtain their ScrollController via inheritance from a PrimaryScrollController widget. '

--- a/lib/wall_builder.dart
+++ b/lib/wall_builder.dart
@@ -53,7 +53,7 @@ class WallSize {
       Size(width.toDouble() * stoneSide, height.toDouble() * stoneSide);
 
   @override
-  int get hashCode => hashList([width, height]);
+  int get hashCode => Object.hashAll([width, height]);
 
   @override
   bool operator ==(Object other) {

--- a/lib/wall_builder.dart
+++ b/lib/wall_builder.dart
@@ -18,8 +18,8 @@ class StoneStartPosition {
 
   /// Computes the absolute brick position in a wall.
   /// [stoneSide] represents the smallest stone width/height.
-  Offset operator *(double stoneSide) =>
-      Offset(this.x * stoneSide, this.y * stoneSide);
+  Offset operator *(Size stoneSide) =>
+      Offset(this.x * stoneSide.width, this.y * stoneSide.height);
 
   @override
   String toString() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.1.1
 repository: https://github.com/GONZALEZD/flutter_wall_layout
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/stone_position_test.dart
+++ b/test/stone_position_test.dart
@@ -13,9 +13,9 @@ void main() {
     });
 
     test("* operator", () {
-      expect(StoneStartPosition(x: 2, y: 10) * 12.0, Offset(24.0, 120.0),
+      expect(StoneStartPosition(x: 2, y: 10) * Size(12.0, 12.0), Offset(24.0, 120.0),
           reason: "Incorrect multiplication.");
-      expect(StoneStartPosition(x: 3, y: 1) * -6.0, Offset(-18.0, -6.0),
+      expect(StoneStartPosition(x: 3, y: 1) * Size(-6.0, -6.0), Offset(-18.0, -6.0),
           reason: "Incorrect multiplication.");
     });
   });

--- a/test/wall_layout_test.dart
+++ b/test/wall_layout_test.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_wall_layout/flutter_wall_layout.dart';
 
-import 'package:flutter_wall_layout/src/wall_layout.dart';
-
 void main() {
   late List<Stone> stones;
   setUp(() {


### PR DESCRIPTION
This is a very useful layout widget for dashboarding! The widget is also working well on flutter web and desktop.

This adds an optional parameter `primaryAxisStoneSize`, which specifies a fixed length of a single stone "unit" in the primary axis direction. Useful for desktop apps where the app width (or height) can be resized continuously and you want to vary the number of wall divisions as the viewport gets wider (or longer).

Using this new option in such a case will be less distracting and smoother and the primary-axis size doesn't keep increasing and decreasing as the cross-axis size changes and number of wall divisions changes.

The default behavior is still to have each stone be an exact square.

This also fixes some deprecation warnings present on more recent flutter versions...